### PR TITLE
Create svelte.config.js for VS Code extension

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,5 @@
+const preprocess = require('svelte-preprocess');
+
+module.exports = {
+	preprocess: preprocess(),
+};


### PR DESCRIPTION
The VS Code Svelte extension requires a `svelte.config.js` file for it to know how to do language preprocessing.

Without this, you'll get red squiggles.

@dceddia you should also update your post to mention this step. I found it listed in a comment at the bottom of the post.